### PR TITLE
Use a private temp directory for certificate

### DIFF
--- a/roles/haproxy/files/self_signed.sh
+++ b/roles/haproxy/files/self_signed.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 tmpcerts=$(mktemp -d)
 trap "rm -rf $tmpcerts" EXIT

--- a/roles/haproxy/files/self_signed.sh
+++ b/roles/haproxy/files/self_signed.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
-openssl req -new -nodes -x509 -subj "/C=US/ST=North Carolina/L=Raleigh/O=IT/CN=moya.trilug.org" -days 3650 -keyout /tmp/server.key -out /tmp/server.crt -extensions v3_ca
-cat /tmp/server.key /tmp/server.crt > /etc/ssl/private/server.pem
+
+tmpcerts=$(mktemp -d)
+trap "rm -rf $tmpcerts" EXIT
+
+openssl req -new -nodes -x509 -subj "/C=US/ST=North Carolina/L=Raleigh/O=IT/CN=moya.trilug.org" -days 3650 -keyout $tmpcerts/server.key -out $tmpcerts/server.crt -extensions v3_ca
+cat $tmpcerts/server.key $tmpcerts/server.crt > /etc/ssl/private/server.pem


### PR DESCRIPTION
Although this is likely to be on a somewhat restricted host, I still
don't like the thought of having a temporary file with the private key
somewhere that would be viewable by a normal user.  Create a temporary
directory to store the generated files which will only be accessible to
the user running the script.  This also cleans up after itself.